### PR TITLE
Fixed: websocket connection close propagated CancelledError to using pub/sub client, causing pub/sub client to give up

### DIFF
--- a/fastapi_websocket_rpc/websocket_rpc_client.py
+++ b/fastapi_websocket_rpc/websocket_rpc_client.py
@@ -232,12 +232,15 @@ class WebSocketRpcClient:
         """
         Join on the internal reader task
         """
-        await self._read_task
+        try:
+            await self._read_task
+        except asyncio.CancelledError:
+            logger.info(f"RPC Reader task was cancelled.")
 
     async def call(self, name, args={}, timeout=None):
         """
         Call a method and wait for a response to be received
-         Args: 
+         Args:
             name (str): name of the method to call on the other side (As defined on the otherside's RpcMethods object)
             args (dict): keyword arguments to be passeds to otherside method
         """

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='fastapi_websocket_rpc',
-    version='0.1.16',
+    version='0.1.17',
     author='Or Weis',
     author_email="or@authorizon.com",
     description="A fast and durable bidirectional JSON RPC channel over Websockets and FastApi.",


### PR DESCRIPTION
background:
- when the server closes the connection, WebsocketRpcClient.close() is [called](https://github.com/authorizon/fastapi_websocket_rpc/blob/master/fastapi_websocket_rpc/websocket_rpc_client.py#L188-L190).
- self.close() [cancels the internal tasks](https://github.com/authorizon/fastapi_websocket_rpc/blob/master/fastapi_websocket_rpc/websocket_rpc_client.py#L163), [including](https://github.com/authorizon/fastapi_websocket_rpc/blob/master/fastapi_websocket_rpc/websocket_rpc_client.py#L173) the reader task
- the CancelledError is propagated to pub/sub, and since [this commit](https://github.com/authorizon/fastapi_websocket_pubsub/commit/1e248d2fbb2885bf25ba33d7533ae7c30439bc09) and the pub/sub gives up when receiving CancelledError.

Solution:
- catch the CancelledError of the reader task inside the rpc client.

Test plan:
- tested on opal server and client
- before this change, ctrl+c on server kill the server -> client does not try to reconnect when losing connection.
- after this change, ctrl+c on server kill the server -> client tries to reconnect until successful (tested by bringing up the server again)